### PR TITLE
fix #11 solved bug in MoveTo

### DIFF
--- a/gcode/main.js
+++ b/gcode/main.js
@@ -1,1 +1,15 @@
-console.log("hello world!")
+import GcodeAPI from './src/API/GcodeApi/GcodeAPI_main/GcodeAPI';
+import G0 from './src/API/GcodeApi/Gcommands/G/G0';
+
+// new G0({ x: 50 })
+// new G0({ x: 50 })
+
+let a = new G0({ x: 70, y: 10 })
+  
+a.moveTo({ left: 100 });
+
+a.moveTo({ left: 80, top: 100 });
+
+a.moveTo({ left: 150, top: 100 });
+
+console.log(GcodeAPI.array);

--- a/gcode/src/API/GcodeApi/Gcommands/G/G0.js
+++ b/gcode/src/API/GcodeApi/Gcommands/G/G0.js
@@ -1,4 +1,5 @@
 import Gcommands from "../Gcommands.js";
+import MoveTo from "../other/Methods/MoveTo/MoveTo.js";
 
 export default class G0 extends Gcommands {
   constructor(_xyzObj) {
@@ -7,7 +8,7 @@ export default class G0 extends Gcommands {
   }
 
   moveTo(_transformObj) {
-    this.newCoordTo = new Gcommands({}).moveTo(_transformObj);
+    this.newCoordTo = new MoveTo(this, _transformObj).getResult();
 
     return new G0(this.newCoordTo).getCode();
   }

--- a/gcode/src/API/GcodeApi/Gcommands/G/G1.js
+++ b/gcode/src/API/GcodeApi/Gcommands/G/G1.js
@@ -1,4 +1,5 @@
 import Gcommands from "../Gcommands.js";
+import MoveTo from "../other/Methods/MoveTo/MoveTo.js";
 
 export default class G1 extends Gcommands {
   constructor(_xyzObj) {
@@ -7,8 +8,8 @@ export default class G1 extends Gcommands {
   }
 
   moveTo(_transformObj) {
-    this.newCoordTo = new Gcommands({}).moveTo(_transformObj);
+    this.newCoordTo = new MoveTo(this, _transformObj).getResult();
 
-    return new G1(this.newCoordTo).getCode();
+    return new G0(this.newCoordTo).getCode();
   }
 }

--- a/gcode/src/API/GcodeApi/Gcommands/Gcommands.js
+++ b/gcode/src/API/GcodeApi/Gcommands/Gcommands.js
@@ -1,5 +1,4 @@
 import GcodeAPI from "../GcodeAPI_main/GcodeAPI.js";
-import MoveTo from "./other/Methods/MoveTo/MoveTo.js";
 
 export default class Gcommands extends GcodeAPI {
   constructor(_xyzObj) {
@@ -8,8 +7,10 @@ export default class Gcommands extends GcodeAPI {
     this.x = parseInt(_xyzObj.x ?? GcodeAPI.previusX ?? 0);
     this.y = parseInt(_xyzObj.y ?? GcodeAPI.previusY ?? 0);
     this.z = parseInt(_xyzObj.z ?? GcodeAPI.previusZ ?? 0);
+    
+    console.log("❌", this);
   }
-
+  
   getCode() {
     this.setLastPosition();
     this.lineOfCode = `${this.prefix} X${this.x} Y${this.y} Z${this.z}`;
@@ -21,9 +22,5 @@ export default class Gcommands extends GcodeAPI {
     GcodeAPI.previusX = this.x;
     GcodeAPI.previusY = this.y;
     GcodeAPI.previusZ = this.z;
-  }
-
-  moveTo(_transformObj) {
-    return new MoveTo(this, _transformObj).getResult();
   }
 }


### PR DESCRIPTION
#11

- the problem happens when you write something similar to this: 
```javascript
G0({x:10}).moveTo({left: 20});
```

- this should return `X30` because 10+20 = 30... 
- but in this case, seems that it does always 0+20 = 20 (so maybe it doesn't get the `G0()` object?)

> what I see is that `G0()` constructor parameter object gets ignored completely once you add `MoveTo()`
> <br> but without MoveTo() the x then get read correctly.
