### PR TITLE
fix #19 angle is working now

### DIFF
--- a/gcode/src/API/GcodeApi/Gsimulator/Gcss/CssLine/CssLine.js
+++ b/gcode/src/API/GcodeApi/Gsimulator/Gcss/CssLine/CssLine.js
@@ -79,7 +79,7 @@ export default class CssLine {
         length: this.lineLength,
         x: this.currentObj.x,
         y: this.currentObj.y,
-        angle: this.currentObj.angle
+        angle: this.lineAngle
       }, null, 2)}`
     );
   }


### PR DESCRIPTION

> **SIMPLE BUG:** 
> <br> in a change in #19, I created a mini-bug that doesn't make the angle be visible
> <br> now is solved in #21

❌ `this.currentObj.angle` -->✅ `this.lineAngle`